### PR TITLE
change panic_implementation to panic_handler

### DIFF
--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(panic_implementation)]
 
 extern crate labrador_ldpc;
 
@@ -7,7 +6,7 @@ use labrador_ldpc::LDPCCode;
 use labrador_ldpc::decoder::DecodeFrom;
 use core::slice;
 
-#[panic_implementation]
+#[panic_handler]
 #[no_mangle]
 pub fn panic(_info: &core::panic::PanicInfo) -> ! {
     loop {}


### PR DESCRIPTION
Compiling master @ 65c0e5cceabfa525353ab491af30f93bfa6a761a with current Rust nightly (as recommended by the README) fails:

```
goblin@host:~/git/labrador-ldpc/capi$ rustc --version
rustc 1.45.0-nightly (769d12eec 2020-05-12)
goblin@host:~/git/labrador-ldpc/capi$ cargo --version
cargo 1.45.0-nightly (cb06cb269 2020-05-08)
goblin@host:~/git/labrador-ldpc/capi$ cargo build --release
   Compiling labrador-ldpc-capi v0.1.2 (/home/goblin/git/labrador-ldpc/capi)
error[E0557]: feature has been removed
 --> src/lib.rs:2:12
  |
2 | #![feature(panic_implementation)]
  |            ^^^^^^^^^^^^^^^^^^^^ feature has been removed
  |
  = note: subsumed by `#[panic_handler]`

error: cannot find attribute `panic_implementation` in this scope
  --> src/lib.rs:10:3
   |
10 | #[panic_implementation]
   |   ^^^^^^^^^^^^^^^^^^^^

error: `#[panic_handler]` function required, but not found

error: aborting due to 3 previous errors

For more information about this error, try `rustc --explain E0557`.
error: could not compile `labrador-ldpc-capi`.

To learn more, run the command again with --verbose.
goblin@host:~/git/labrador-ldpc/capi$
```

This PR *seems* to fix it, although I've no idea if that's the correct way to do it, I haven't tested it any more than just compiling, and it may break horribly. If I fixed it incorrectly, please just consider this PR as a bug report of the compilation issue.