### PR TITLE
Fix some panic areas

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -33,28 +33,33 @@ pub trait DecodeFrom:
     fn abs(&self)       -> Self;
     /// Saturating add
     fn saturating_add(&self, other: Self) -> Self;
+    /// Saturating sub
+    fn saturating_sub(&self, other: Self) -> Self;
 }
 
 impl DecodeFrom for i8 {
     #[inline] fn one()      -> i8 { 1 }
     #[inline] fn zero()     -> i8 { 0 }
     #[inline] fn maxval()   -> i8 { i8::MAX }
-    #[inline] fn abs(&self) -> i8 { i8::abs(*self) }
+    #[inline] fn abs(&self) -> i8 { i8::saturating_abs(*self) }
     #[inline] fn saturating_add(&self, other: Self) -> Self { i8::saturating_add(*self, other) }
+    #[inline] fn saturating_sub(&self, other: Self) -> Self { i8::saturating_sub(*self, other) }
 }
 impl DecodeFrom for i16 {
     #[inline] fn one()      -> i16 { 1 }
     #[inline] fn zero()     -> i16 { 0 }
     #[inline] fn maxval()   -> i16 { i16::MAX }
-    #[inline] fn abs(&self) -> i16 { i16::abs(*self) }
+    #[inline] fn abs(&self) -> i16 { i16::saturating_abs(*self) }
     #[inline] fn saturating_add(&self, other: Self) -> Self { i16::saturating_add(*self, other) }
+    #[inline] fn saturating_sub(&self, other: Self) -> Self { i16::saturating_sub(*self, other) }
 }
 impl DecodeFrom for i32 {
     #[inline] fn one()      -> i32 { 1 }
     #[inline] fn zero()     -> i32 { 0 }
     #[inline] fn maxval()   -> i32 { i32::MAX }
-    #[inline] fn abs(&self) -> i32 { i32::abs(*self) }
+    #[inline] fn abs(&self) -> i32 { i32::saturating_abs(*self) }
     #[inline] fn saturating_add(&self, other: Self) -> Self { i32::saturating_add(*self, other) }
+    #[inline] fn saturating_sub(&self, other: Self) -> Self { i32::saturating_sub(*self, other) }
 }
 impl DecodeFrom for f32 {
     #[inline] fn one()      -> f32 { 1.0 }
@@ -62,6 +67,7 @@ impl DecodeFrom for f32 {
     #[inline] fn maxval()   -> f32 { f32::MAX }
     #[inline] fn abs(&self) -> f32 { f32::from_bits(self.to_bits() & 0x7FFF_FFFF) }
     #[inline] fn saturating_add(&self, other: Self) -> Self { *self + other }
+    #[inline] fn saturating_sub(&self, other: Self) -> Self { *self - other }
 }
 impl DecodeFrom for f64 {
     #[inline] fn one()      -> f64 { 1.0 }
@@ -69,6 +75,7 @@ impl DecodeFrom for f64 {
     #[inline] fn maxval()   -> f64 { f64::MAX }
     #[inline] fn abs(&self) -> f64 { f64::from_bits(self.to_bits() & 0x7FFF_FFFF_FFFF_FFFF) }
     #[inline] fn saturating_add(&self, other: Self) -> Self { *self + other }
+    #[inline] fn saturating_sub(&self, other: Self) -> Self { *self - other }
 }
 
 impl LDPCCode {
@@ -393,7 +400,7 @@ impl LDPCCode {
             idx = 0;
             for (check, var) in self.iter_paritychecks() {
                 // Work out messages to this parity check
-                let new_v_ai = va[var] - u[idx];
+                let new_v_ai = va[var].saturating_sub(u[idx]);
                 if v[idx] != T::zero() && (new_v_ai >= T::zero()) != (v[idx] >= T::zero()) {
                     v[idx] = T::zero();
                 } else {


### PR DESCRIPTION
I was messing around with a fuzzer and found a few areas that could panic with the wrong input. After making these changes, the fuzzer can't find any more issues.

I don't understand the LDPC algorithm at all, so it would be good to be extra careful when reviewing. The unit tests in this project + in my own project are still passing, so I didn't completely break anything, at least.